### PR TITLE
[sbd2015] Wskazać poprawne zapytanie SQL (dialekt ORACLE) znajdujące średnie zarobki tylko tych departamentów, które zatrudniają wiecej, niż trzech pracowników:

### DIFF
--- a/overrides/sbd2015.json
+++ b/overrides/sbd2015.json
@@ -18,6 +18,11 @@
           "answer": "SELECT deptno, AVG(sal) FROM emp HAVING COUNT (*) &gt; 3;GROUP BY deptno;",
           "correct": false,
           "isMarkdown": false
+        },
+        {
+          "answer": "SELECT deptno, AVG(sal) as avg_sal FROM emp GROUP BY deptno HAVING COUNT(*) > 3;",
+          "correct": true,
+          "isMarkdown": false
         }
       ]
     }

--- a/overrides/sbd2015.json
+++ b/overrides/sbd2015.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../schemas/subject-override.json",
+  "id": "sbd2015",
+  "updatedAt": 1676115446340,
+  "data": [
+    {
+      "id": 2431,
+      "question": "Wskazać poprawne zapytanie SQL (dialekt ORACLE) znajdujące średnie zarobki tylko tych departamentów, które zatrudniają wiecej, niż trzech pracowników:",
+      "isMarkdown": false,
+      "comments": [],
+      "answers": [
+        {
+          "answer": "SELECT deptno, AVG(sal) FROM emp GROUP BY deptno WHERE COUNT(*) &gt; 3;",
+          "correct": false,
+          "isMarkdown": false
+        },
+        {
+          "answer": "SELECT deptno, AVG(sal) FROM emp HAVING COUNT (*) &gt; 3;GROUP BY deptno;",
+          "correct": false,
+          "isMarkdown": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
jak dla mnie nie ma tu poprawnej odpowiedzi, ale na pewno zaznaczona jest błędna