### PR TITLE
Correction to tak question

### DIFF
--- a/overrides/tak_ang.json
+++ b/overrides/tak_ang.json
@@ -1,7 +1,29 @@
 {
-  "$schema":"../schemas/subject-override.json",
-  "title": "Technika i Architekture Komputerów [ENG]",
+  "$schema": "../schemas/subject-override.json",
   "id": "tak_ang",
-  "data": [],
-  "updatedAt": 1659139863868
+  "title": "Technika i Architekture Komputerów [ENG]",
+  "updatedAt": 1676212387535,
+  "data": [
+    {
+      "question": "<span lang=\"EN-US\">In 8-bit code the signed number representation</span>",
+      "isMarkdown": false,
+      "answers": [
+        {
+          "answer": "<span lang=\"EN-US\">11111111 represents value 0</span>",
+          "correct": false,
+          "isMarkdown": false
+        },
+        {
+          "answer": "<span lang=\"EN-US\">11110000 represents value -16</span>",
+          "correct": false,
+          "isMarkdown": false
+        },
+        {
+          "answer": "<span lang=\"EN-US\">11110000 represents value -15</span>",
+          "correct": false,
+          "isMarkdown": false
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
First is marked correct (1111 1111 = 0) in signed num representation, which is, in reality, incorrect. This time I have a source xD. In signed num representation first bit (1000 0000) first 1 represents -, so (1000 0000 = -0) and (0000 0000 = +0) respectively. Other bits a just a postive number, so (1111 1111 != 0, = -127). According to: https://en.wikipedia.org/wiki/Signed_number_representations#:~:text=In%20computing%2C%20signed%20number%20representations,sign%20("−").