### PR TITLE
[RBD]  Funkcja IIf umożliwia:

### DIFF
--- a/overrides/rbd.json
+++ b/overrides/rbd.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../schemas/subject-override.json",
   "id": "rbd",
-  "updatedAt": 1676489317350,
+  "updatedAt": 1719739066544,
   "data": [
     {
       "id": 3281,
@@ -28,6 +28,32 @@
           "answer": "`SELECT Osoby.Nazwisko, Osoby.Imię, Osoby.Id_działu WHERE Działy.Nazwa = 'PRAWNY';`",
           "correct": false,
           "isMarkdown": true
+        }
+      ]
+    },
+    {
+      "question": "Funkcja IIf umożliwia:",
+      "isMarkdown": false,
+      "answers": [
+        {
+          "answer": "obliczenie liczby stron z jakich składa się raport",
+          "correct": false,
+          "isMarkdown": false
+        },
+        {
+          "answer": "zinterpretowanie Null jako napisu pustego",
+          "correct": true,
+          "isMarkdown": false
+        },
+        {
+          "answer": "zapisanie warunku w kodzie",
+          "correct": true,
+          "isMarkdown": false
+        },
+        {
+          "answer": "wywołanie kodu z makra",
+          "correct": false,
+          "isMarkdown": false
         }
       ]
     }


### PR DESCRIPTION
Funkcja IIf w Microsoft Access i innych środowiskach baz danych umożliwia tworzenie wyrażeń warunkowych, które zwracają jedną z dwóch wartości w zależności od wyniku warunku logicznego. 

Zinterpretowanie Null jako napisu pustego:
Można użyć funkcji IIf, aby zinterpretować wartość NULL jako pusty napis. Przykład:
`IIf(IsNull([Pole]), "", [Pole])`

Zapisanie warunku w kodzie:
Funkcja IIf umożliwia zapisanie warunku logicznego w kodzie i określenie wartości zwracanej w zależności od tego, czy warunek jest spełniony (TRUE) czy nie (FALSE). Przykład:
`IIf([Wiek] >= 18, "Dorosły", "Nieletni")`


# Source backing up the changes 🔍
https://www.w3schools.com/sql/func_sqlserver_iif.asp

## Type of change 🦄
- [x] Changing the correct answers