### PR TITLE
[TIN] Numery portów są przekazywane w ramach:

### DIFF
--- a/overrides/patches/tin/3439.patch.json
+++ b/overrides/patches/tin/3439.patch.json
@@ -1,0 +1,29 @@
+{
+  "id": "3439",
+  "question": "Numery portów są przekazywane w ramach:",
+  "isMarkdown": false,
+  "answers": [
+    {
+      "answer": "protokołu aplikacyjnego",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "protokołu warstwy sprzętowej",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "protokołu transportowego",
+      "correct": true,
+      "isMarkdown": false
+    },
+    {
+      "answer": "protokołu warstwy sieciowej",
+      "correct": false,
+      "isMarkdown": false
+    }
+  ],
+  "createdAt": 1738700523958,
+  "$schema": "../../../schemas/subject-patch.json"
+}


### PR DESCRIPTION
Poprawa prawidłowej odpowiedzi:
[https://networkengineering.stackexchange.com/questions/16996/what-layer-of-the-osi-model-deals-with-ports](https://networkengineering.stackexchange.com/questions/16996/what-layer-of-the-osi-model-deals-with-ports)
GPT: 
Uzasadnienie: Porty są używane w protokołach transportowych, takich jak TCP (Transmission Control Protocol) i UDP (User Datagram Protocol), aby zidentyfikować konkretne usługi lub aplikacje działające na urządzeniu w sieci. Numer portu pozwala na określenie, która aplikacja ma obsługiwać dany strumień danych.
Protokół transportowy (np. TCP, UDP) odpowiada za komunikację między aplikacjami na różnych hostach i używa numerów portów do adresowania aplikacji.
Porty pomagają rozróżnić różne usługi działające na tym samym urządzeniu (np. port 80 dla HTTP, port 443 dla HTTPS).
Inne opcje:
Protokół aplikacyjny – numery portów mogą być używane przez protokoły aplikacyjne, ale same porty są zarządzane na poziomie protokołu transportowego.
Protokół warstwy sprzętowej – warstwa sprzętowa (np. Ethernet) nie używa numerów portów. Ta warstwa jest odpowiedzialna za fizyczne przesyłanie danych.
Protokół warstwy sieciowej – warstwa sieciowa (np. IP) jest odpowiedzialna za adresowanie hostów i trasowanie danych, ale nie zarządza numerami portów.
