### PR TITLE
[sbd] Wskazać poprawne (w Oraclu) zapytanie SQL znajdujące średnie zarobki tylko tych departamentów, które zatrudniają więcej niż trzech pracowników.

### DIFF
--- a/overrides/patches/sbd/2388.patch.json
+++ b/overrides/patches/sbd/2388.patch.json
@@ -1,0 +1,24 @@
+{
+  "id": "2388",
+  "question": "<span>Wskazać poprawne (w Oraclu) zapytanie SQL znajdujące średnie zarobki tylko tych departamentów, które zatrudniają więcej niż trzech pracowników.</span>",
+  "isMarkdown": false,
+  "answers": [
+    {
+      "answer": "<span>SELECT deptno, AVG(sal) FROM emp HAVING COUNT (*) &gt; 3 GROUP BY deptno;</span>",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "<span>SELECT deptno, AVG(sal) FROM emp GROUP BY deptno HAVING COUNT (*) &gt; 3;</span>",
+      "correct": true,
+      "isMarkdown": false
+    },
+    {
+      "answer": "<table>\n<tbody>\n<tr>\n<td>SELECT deptno, AVG(sal) FROM emp GROUP BY deptno WHERE COUNT (*) &gt; 3;</td>\n<td>&nbsp;</td>\n</tr>\n</tbody>\n</table>",
+      "correct": false,
+      "isMarkdown": false
+    }
+  ],
+  "createdAt": 1739143057413,
+  "$schema": "../../../schemas/subject-patch.json"
+}


### PR DESCRIPTION
Klauzula Having musi zawsze występować po GROUP BY.

https://www.geeksforgeeks.org/difference-between-having-clause-and-group-by-clause/


## Type of change 🦄
- [x] Changing the correct answers
- [ ] Adding new question
- [ ] Fixing typos/formatting
- [ ] Other (what?)

## Checklist 📝
- [x] I have copied the whole JSON contents from zdaj.se guide (if relevant)
- [x] I have added a relevant source for the changes
- [x] I have checked that all of the correct answers are marked as correct
- [x] I have changed the pull request's title to reflect the changed question
- [x] I have checked if there are no other pull requests [here](https://github.com/bibixx/zdaj-se-pjatk-data/pulls?q=is%3Aopen+is%3Apr) that change the same question

## Attribution 👨🏻‍💻
- [ ] I want to have my name displayed on zdaj.se near this change (not required, will be added in the future)

