### PR TITLE
[SKO1-SKJ] Kategoria 5. kabla UTD umożliwia stosowanie technologii [10Base2, 10Base5, 10BaseF, 10BaseTX]

### DIFF
--- a/overrides/patches/sko1-skj/2911.patch.json
+++ b/overrides/patches/sko1-skj/2911.patch.json
@@ -1,0 +1,29 @@
+{
+  "id": "2911",
+  "question": "Kategoria 5. kabla UTD umożliwia stosowanie technologii",
+  "isMarkdown": false,
+  "answers": [
+    {
+      "answer": "10Base2",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "10Base5",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "10BaseF",
+      "correct": false,
+      "isMarkdown": false
+    },
+    {
+      "answer": "10BaseTX",
+      "correct": true,
+      "isMarkdown": false
+    }
+  ],
+  "createdAt": 1739555218163,
+  "$schema": "../../../schemas/subject-patch.json"
+}


### PR DESCRIPTION
<!--
  ⬆️ CHANGE PULL REQUEST TITLE ⬆️
  Please change the pull request's title to match the following format: [SUBJECT_ID] QUESTION CONTENTS (eg. [sbd2015] Wskazać poprawne zapytanie SQL [...])
-->

<!--
  NOTE: Feel free to fill all of those in Polish 🇵🇱
-->

# Source backing up the changes 🔍
<!--
  Please include a source or an explanation of the change. This can include (but is not limited to):
  • Link a to Wikipedia
  • ChatGPT answer, preferably followed with some external link
  • Link to a relevant part in the lecture
  • Link to an official documentation
  • Stack overflow question
  • Thorough explanation 

  🚨🚨 WARNING: Pull requests without sources will be closed without further questions 🚨🚨
--> 
### reasoning part (o3-mini-high)
The user is asking about what technologies can be used with Category 5 cables. The list includes 10Base2, 10Base5, 10BaseF, and 10BaseTX. The question might be: “Which technology can be used with Category 5 cable?”

10Base2 (coaxial cable, bus topology) is for thin coaxial cables. Wait, I’ll need to check if "UTP" refers to "UTD" in the context of this question; I’m unsure about that.

I'll now review more about Category 5 cable and its compatibilities with these technologies.

Category 5 cable supports Ethernet over twisted pair, like 10Base-T and 100Base-TX. So, 10BaseTX could be a correct answer, but "10Base-T" is more common for basic Ethernet over twisted pair.

Let me review the options:

10Base2 uses thin coaxiry cables.
10Base5 uses thick coax cables.
10BaseF likely refers to fiber optic, which wouldn’t work with Category 5 cable.
10BaseTX should work with Category 5 twisted pair cables.
I also wonder if “UTD” is just a typo for “UTP” (Unshielded Twisted Pair).
### odp
Kabel kategorii 5 (UTP) jest przystosowany do przesyłania sygnału w sieciach Ethernet, dlatego umożliwia stosowanie technologii 10BaseTX.

10Base2 i 10Base5 to technologie oparte na kablach koncentrycznych, a nie na skrętkach.
10BaseF odnosi się do technologii światłowodowej.
W związku z tym poprawną odpowiedzią jest 10BaseTX.

## Type of change 🦄
- [x] Changing the correct answers
- [ ] Adding new question
- [ ] Fixing typos/formatting
- [ ] Other (what?)

## Checklist 📝
- [x] I have copied the whole JSON contents from zdaj.se guide (if relevant)
- [x] I have added a relevant source for the changes
- [x] I have checked that all of the correct answers are marked as correct
- [x] I have changed the pull request's title to reflect the changed question
- [x] I have checked if there are no other pull requests [here](https://github.com/bibixx/zdaj-se-pjatk-data/pulls?q=is%3Aopen+is%3Apr) that change the same question

## Attribution 👨🏻‍💻
- [ ] I want to have my name displayed on zdaj.se near this change (not required, will be added in the future)

<!--
  If you have any questions or doubts, feel free to drop an email to zdaj@zdaj.se
  or create this PR without all of the required fields but with a comment asking about them.
-->
